### PR TITLE
Update rkllm.h

### DIFF
--- a/rkllm-runtime/Linux/librkllm_api/include/rkllm.h
+++ b/rkllm-runtime/Linux/librkllm_api/include/rkllm.h
@@ -1,5 +1,6 @@
 #ifndef _RKLLM_H_
 #define _RKLLM_H_
+#include <cstdint>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
while compiling on local SBC with gcc/g++, cstdint.h is missing