### PR TITLE
Fix model image token and embed size assignments

### DIFF
--- a/examples/multimodal_model_demo/deploy/src/image_enc.cc
+++ b/examples/multimodal_model_demo/deploy/src/image_enc.cc
@@ -77,8 +77,8 @@ int init_imgenc(const char* model_path, rknn_app_context_t* app_ctx, const int c
         dump_tensor_attr(&(output_attrs[i]));
     }
     // Set to context
-    app_ctx->model_image_token = output_attrs[0].dims[1];
-    app_ctx->model_embed_size = output_attrs[0].dims[2];
+    app_ctx->model_image_token = output_attrs[0].dims[0];
+    app_ctx->model_embed_size = output_attrs[0].dims[1];
     app_ctx->rknn_ctx = ctx;
     app_ctx->io_num = io_num;
     app_ctx->input_attrs = (rknn_tensor_attr*)malloc(io_num.n_input * sizeof(rknn_tensor_attr));


### PR DESCRIPTION
An assigment error in the `app_ctx->model_image_token` and `app_ctx->model_embed_size` causes segmentation errors when running the supplied version 1.2.2 of `Qwen2-VL-2B_vision_rk3588.rknn`